### PR TITLE
Fix 32 bit build

### DIFF
--- a/ropgun.c
+++ b/ropgun.c
@@ -112,12 +112,16 @@ int trace_child(pid_t child, int mode)
             };
             //ptrace(PTRACE_GETREGS, child, NULL, &regs);
             ptrace(PTRACE_GETREGSET, child, NT_PRSTATUS, &x86_io);
+#ifdef __x86_64__
             if (x86_io.iov_len == sizeof(struct i386_user_regs_struct)) {
                 // this is a 32-bit process
                 fprintf(stderr, ANSI_COLOR_BLUE "%s()" ANSI_COLOR_RESET "\n", callname32(regs.i386_r.orig_eax));
             } else {
                 fprintf(stderr, ANSI_COLOR_CYAN "%s()" ANSI_COLOR_RESET "\n", callname(regs.x86_64_r.orig_rax));
             }
+#else
+            fprintf(stderr, ANSI_COLOR_BLUE "%s()" ANSI_COLOR_RESET "\n", callname32(regs.i386_r.orig_eax));
+#endif
         }
 
         ioctl(fd1, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP);


### PR DESCRIPTION
32 bit build fails with error:

ropgun.c:119:101: error: 'struct user_regs_struct' has no member named 'orig_rax'
                 fprintf(stderr, ANSI_COLOR_CYAN "%s()" ANSI_COLOR_RESET "\n", callname(regs.x86_64_r.orig_rax));

Fix it.